### PR TITLE
ci: harden GitHub Actions security

### DIFF
--- a/.github/actions/parse/action.yml
+++ b/.github/actions/parse/action.yml
@@ -51,7 +51,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup pixi
-      uses: prefix-dev/setup-pixi@v0.9.3
+      uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
       with:
         pixi-version: v0.49.0
         environments: kibana

--- a/.github/actions/parse/action.yml
+++ b/.github/actions/parse/action.yml
@@ -58,17 +58,30 @@ runs:
 
     - name: Parse log file
       shell: bash
+      env:
+        JOB: ${{ inputs.job }}
+        LOG_FILE: ${{ inputs.log-file }}
+        LOG_TYPE: ${{ inputs.log-type }}
+        CLUSTER: ${{ inputs.cluster }}
+        KIBANA_TOKEN: ${{ inputs.kibana-token }}
+        KIBANA_KIND: ${{ inputs.kibana-kind }}
+        HOST: ${{ inputs.host }}
+        PAYLOAD_FILE: ${{ inputs.payload-file }}
+        OS: ${{ inputs.os }}
+        MODE: ${{ inputs.mode }}
+        CONTAINERIZED: ${{ inputs.containerized }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
       run: |
         pixi run -e kibana python -m parsing.scripts.ci_parse \
-          --job "${{ inputs.job }}" \
-          --log-file "${{ inputs.log-file }}" \
-          --log-type "${{ inputs.log-type }}" \
-          --cluster "${{ inputs.cluster }}" \
-          --token "${{ inputs.kibana-token }}" \
-          --kind "${{ inputs.kibana-kind }}" \
-          --host "${{ inputs.host }}" \
-          --payload-file "${{ inputs.payload-file }}" \
-          --os "${{ inputs.os }}" \
-          --mode "${{ inputs.mode }}" \
-          --containerized "${{ inputs.containerized }}" \
-          --output "${{ inputs.output-file }}"
+          --job "$JOB" \
+          --log-file "$LOG_FILE" \
+          --log-type "$LOG_TYPE" \
+          --cluster "$CLUSTER" \
+          --token "$KIBANA_TOKEN" \
+          --kind "$KIBANA_KIND" \
+          --host "$HOST" \
+          --payload-file "$PAYLOAD_FILE" \
+          --os "$OS" \
+          --mode "$MODE" \
+          --containerized "$CONTAINERIZED" \
+          --output "$OUTPUT_FILE"

--- a/.github/actions/setup-globus/action.yml
+++ b/.github/actions/setup-globus/action.yml
@@ -17,13 +17,12 @@ runs:
       shell: bash
 
     - name: Create files
+      env:
+        VOMS_USERCERT: ${{ inputs.voms-usercert }}
+        VOMS_USERKEY: ${{ inputs.voms-userkey }}
       run: |
-        cat > ~/.globus/usercert.pem << 'EOF'
-        ${{ inputs.voms-usercert }}
-        EOF
-        cat > ~/.globus/userkey.pem << 'EOF'
-        ${{ inputs.voms-userkey }}
-        EOF
+        printf '%s\n' "$VOMS_USERCERT" > ~/.globus/usercert.pem
+        printf '%s\n' "$VOMS_USERKEY" > ~/.globus/userkey.pem
       shell: bash
 
     - name: Set permissions

--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -13,23 +13,28 @@ runs:
   steps:
     - name: Validate payload file
       shell: bash
+      env:
+        PAYLOAD_FILE: ${{ inputs.payload-file }}
       run: |
-        if [ ! -f "${{ inputs.payload-file }}" ]; then
-          echo "Error: Payload file not found: ${{ inputs.payload-file }}"
+        if [ ! -f "$PAYLOAD_FILE" ]; then
+          echo "Error: Payload file not found: $PAYLOAD_FILE"
           exit 1
         fi
-        echo "Payload file found: ${{ inputs.payload-file }}"
+        echo "Payload file found: $PAYLOAD_FILE"
         echo "::group::File contents"
-        cat "${{ inputs.payload-file }}" || true
+        cat "$PAYLOAD_FILE" || true
         printf "\n"
         echo "::endgroup::"
 
     - name: Upload to LogStash
       shell: bash
+      env:
+        PAYLOAD_FILE: ${{ inputs.payload-file }}
+        KIBANA_URI: ${{ inputs.kibana-uri }}
       run: |
-        response=$(curl -X POST "${{ inputs.kibana-uri }}" \
+        response=$(curl -X POST "$KIBANA_URI" \
           -H "Content-Type: application/json" \
-          -d @${{ inputs.payload-file }} \
+          -d @"$PAYLOAD_FILE" \
           -w "%{http_code}" \
           -s -o response.txt)
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-globus
         with:
           voms-usercert: ${{ secrets.VOMS_USERCERT }}
@@ -30,6 +32,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
         with:
@@ -63,6 +66,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: parse ${{ matrix.log-type }} log
         uses: ./.github/actions/parse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ permissions:
 
 jobs:
   test-actions:
+    if:
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork == false
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   test-actions:
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-globus
         with:
           voms-usercert: ${{ secrets.VOMS_USERCERT }}
@@ -27,11 +27,11 @@ jobs:
   test-handlers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: prefix-dev/setup-pixi@v0.10.1
+      - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
         with:
           pixi-version: v0.49.0
           environments: kibana
@@ -60,7 +60,7 @@ jobs:
             log-type: "truth3"
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,11 +16,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: prefix-dev/setup-pixi@v0.10.1
+      - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
         with:
           pixi-version: v0.49.0
           environments: docs
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload static files as artifact
         id: deployment
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,6 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
         with:

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -24,6 +24,6 @@ jobs:
 
     steps:
       - name: Check PR title matches Conventional Commits spec
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/uchicago.yml
+++ b/.github/workflows/uchicago.yml
@@ -68,7 +68,9 @@ jobs:
             rucio.log
 
   evnt-native:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -111,7 +113,9 @@ jobs:
             log.generate
 
   evnt-el9:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -154,7 +158,9 @@ jobs:
             log.generate
 
   evnt-centos7:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -197,7 +203,9 @@ jobs:
             log.generate
 
   truth3-native:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -240,7 +248,9 @@ jobs:
             log.Derivation
 
   truth3-el9:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -283,7 +293,9 @@ jobs:
             log.Derivation
 
   truth3-centos7:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -326,7 +338,9 @@ jobs:
             log.EVNTtoDAOD
 
   coffea:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -370,7 +384,9 @@ jobs:
             coffea_hist.log
 
   eventloop-columnar:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -413,7 +429,9 @@ jobs:
             eventloop_arrays.log
 
   eventloop-standard:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -456,7 +474,9 @@ jobs:
             eventloop_noarrays.log
 
   fastframes:
-    if: github.actor != 'dependabot[bot]'
+    if:
+      github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/uchicago.yml
+++ b/.github/workflows/uchicago.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-globus
         with:
@@ -70,6 +72,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./EVNT/UC/Native/run_evnt_native_batch.sh
@@ -111,6 +115,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./EVNT/UC/EL9/run_evnt_el9_batch.sh
@@ -152,6 +158,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./EVNT/UC/CentOS7/run_evnt_centos7_batch.sh
@@ -193,6 +201,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./TRUTH3/UC/Native/run_truth3_native_batch.sh
@@ -234,6 +244,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./TRUTH3/UC/EL9/run_truth3_el9_batch.sh
@@ -275,6 +287,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./TRUTH3/UC/CentOS7/run_truth3_centos7_batch.sh
@@ -316,6 +330,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./NTuple_Hist/coffea/UC/run_example.sh
@@ -358,6 +374,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./NTuple_Hist/event_loop/UC/columnar/run_eventloop_arrays.sh
@@ -399,6 +417,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: execute
         run: ./NTuple_Hist/event_loop/UC/standard/run_eventloop_noarrays.sh
@@ -440,6 +460,8 @@ jobs:
     runs-on: arc-runner-set-uchicago
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-globus
         with:

--- a/.github/workflows/uchicago.yml
+++ b/.github/workflows/uchicago.yml
@@ -22,7 +22,7 @@ jobs:
       || github.event.pull_request.head.repo.fork == false)
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/setup-globus
         with:
@@ -59,7 +59,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -69,7 +69,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./EVNT/UC/Native/run_evnt_native_batch.sh
@@ -100,7 +100,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -110,7 +110,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./EVNT/UC/EL9/run_evnt_el9_batch.sh
@@ -141,7 +141,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -151,7 +151,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./EVNT/UC/CentOS7/run_evnt_centos7_batch.sh
@@ -182,7 +182,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -192,7 +192,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./TRUTH3/UC/Native/run_truth3_native_batch.sh
@@ -223,7 +223,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -233,7 +233,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./TRUTH3/UC/EL9/run_truth3_el9_batch.sh
@@ -264,7 +264,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -274,7 +274,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./TRUTH3/UC/CentOS7/run_truth3_centos7_batch.sh
@@ -305,7 +305,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -315,7 +315,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./NTuple_Hist/coffea/UC/run_example.sh
@@ -347,7 +347,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -357,7 +357,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./NTuple_Hist/event_loop/UC/columnar/run_eventloop_arrays.sh
@@ -388,7 +388,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -398,7 +398,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: execute
         run: ./NTuple_Hist/event_loop/UC/standard/run_eventloop_noarrays.sh
@@ -429,7 +429,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |
@@ -439,7 +439,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: arc-runner-set-uchicago
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/setup-globus
         with:
@@ -477,7 +477,7 @@ jobs:
 
       - name: upload log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.job }}-logs
           path: |

--- a/.github/workflows/uchicago.yml
+++ b/.github/workflows/uchicago.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - uses: ./.github/actions/setup-globus
         with:
           voms-usercert: ${{ secrets.VOMS_USERCERT }}
@@ -47,7 +50,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: alma9
           mode: batch
           containerized: "false"
@@ -77,6 +80,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./EVNT/UC/Native/run_evnt_native_batch.sh
         working-directory: .
@@ -92,7 +98,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: alma9
           mode: batch
           containerized: "false"
@@ -122,6 +128,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./EVNT/UC/EL9/run_evnt_el9_batch.sh
         working-directory: .
@@ -137,7 +146,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: alma9
           mode: batch
           containerized: "true"
@@ -167,6 +176,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./EVNT/UC/CentOS7/run_evnt_centos7_batch.sh
         working-directory: .
@@ -182,7 +194,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: centos7
           mode: batch
           containerized: "true"
@@ -212,6 +224,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./TRUTH3/UC/Native/run_truth3_native_batch.sh
         working-directory: .
@@ -227,7 +242,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: alma9
           mode: batch
           containerized: "false"
@@ -257,6 +272,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./TRUTH3/UC/EL9/run_truth3_el9_batch.sh
         working-directory: .
@@ -272,7 +290,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: alma9
           mode: batch
           containerized: "true"
@@ -302,6 +320,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./TRUTH3/UC/CentOS7/run_truth3_centos7_batch.sh
         working-directory: .
@@ -317,7 +338,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: centos7
           mode: batch
           containerized: "true"
@@ -347,6 +368,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./NTuple_Hist/coffea/UC/run_example.sh
         working-directory: .
@@ -362,7 +386,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           payload-file: coffea.root
           os: alma9
           mode: batch
@@ -393,6 +417,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./NTuple_Hist/event_loop/UC/columnar/run_eventloop_arrays.sh
         working-directory: .
@@ -408,7 +435,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: alma9
           mode: batch
           containerized: "false"
@@ -438,6 +465,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - name: execute
         run: ./NTuple_Hist/event_loop/UC/standard/run_eventloop_noarrays.sh
         working-directory: .
@@ -453,7 +483,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           os: alma9
           mode: batch
           containerized: "false"
@@ -483,6 +513,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Export node name
+        run: echo "NODE_NAME=$NODE_NAME" >> "$GITHUB_ENV"
+
       - uses: ./.github/actions/setup-globus
         with:
           voms-usercert: ${{ secrets.VOMS_USERCERT }}
@@ -504,7 +537,7 @@ jobs:
           cluster: UC-AF
           kibana-token: ${{ secrets.KIBANA_TOKEN || 'default-token' }}
           kibana-kind: "benchmark"
-          host: ${NODE_NAME}
+          host: ${{ env.NODE_NAME }}
           payload-file: ./NTuple_Hist/fastframes/UC/example_FS.root
           os: alma9
           mode: batch

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# dangerous-triggers ignore below: semantic-pr-check.yml never checks out the
+# pull request's code (no `actions/checkout` step at all) and only reads PR
+# metadata (title) via the GitHub API through amannn/action-semantic-pull-request.
+# pull_request_target is used deliberately here so that PRs from forks still
+# get a token with `statuses: write` to report the check; a `pull_request`
+# trigger would be forced read-only for fork PRs and silently fail to post
+# the status, defeating the purpose of validating first-time contributors'
+# PR titles.
+rules:
+  dangerous-triggers:
+    ignore:
+      - semantic-pr-check.yml:3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ exclude: ^.cruft.json|.copier-answers.yml|docs/css/fonts/.*|parsing/example-logs
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.20.0"
+    rev: "fda77690955e9b63c6687d8806bafd56a526e45f" # frozen: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==24.*]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v6.0.0"
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c" # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -35,35 +35,35 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.10.0"
+    rev: "3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316" # frozen: v1.10.0
     hooks:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.9.6"
+    rev: "0ee178619d696787ca73d210cc191d720868c631" # frozen: v3.9.6
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.2"
+    rev: "7c55798a78262d14b2074abf623d8a992ebb70d4" # frozen: v0.16.2
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.4.3"
+    rev: "57b21406f092110c18776e39b0bda50d37c945c8" # frozen: v2.4.3
     hooks:
       - id: codespell
         exclude: ^.+.ipynb$
         args: ["-w", "-L", "SLAC,checkin,slac"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.11.0.1"
+    rev: "745eface02aef23e168a8afb6b5737818efbea95" # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
 
@@ -76,15 +76,17 @@ repos:
         exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.38.0"
+    rev: "12e63946db2c5cfcc9030fac21c3883ba88c6ed8" # frozen: 0.38.0
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
       - id: check-readthedocs
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa  # frozen: v1.29.0
+    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa # frozen: v1.29.0
     hooks:
       - id: zizmor
-        files: "^\\.github"
-        args: [--persona=pedantic]
+        # --min-severity=low drops the pedantic persona's informational-only
+        # anonymous-definition (job naming) findings so the hook doesn't fail
+        # on style nits; real security findings are all low severity or above.
+        args: [--persona=pedantic, --min-severity=low]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
+  autoupdate_schedule: monthly
 
 exclude: ^.cruft.json|.copier-answers.yml|docs/css/fonts/.*|parsing/example-logs/.*$
 
@@ -80,3 +81,10 @@ repos:
       - id: check-dependabot
       - id: check-github-workflows
       - id: check-readthedocs
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa  # frozen: v1.29.0
+    hooks:
+      - id: zizmor
+        files: "^\\.github"
+        args: [--persona=pedantic]


### PR DESCRIPTION
## Summary

CI-security hardening pass: pin all GitHub Actions to SHAs, fix zizmor findings, add zizmor as a pre-commit hook, add a dependabot cooldown, and close a gap where fork PRs could run arbitrary code on the self-hosted runner.

## Changes

- **Pin all GitHub Actions to SHAs** (`npx actions-up`), each with a `# vX.Y.Z` comment. Verified every pin against the upstream tag ref.
- **Fix zizmor `template-injection` findings**: the `parse`, `setup-globus`, and `upload` composite actions interpolated `${{ inputs.* }}` directly into `run:` shell blocks. Routed all of them through `env:` instead.
- **Fix zizmor `artipacked` findings**: added `persist-credentials: false` to every `actions/checkout` step (none of these jobs need to push using the checkout token).
- **Fix zizmor `excessive-permissions` finding**: added a workflow-level `permissions: contents: read` to `docs.yml` so the `build` job no longer runs with default permissions (the `deploy` job already had its own narrower explicit grant).
- **Added zizmor `--persona=pedantic` as a pre-commit hook**, scoped with `--min-severity=low` so it doesn't fail on the persona's informational-only job-naming nits (see "zizmor ignores" below for the one real ignore).
- **Dependabot**: added a 7-day cooldown to the `github-actions` group, switched it to monthly, and renamed the group key from the deprecated `actions` alias to `github-actions`.
- **`.pre-commit-config.yaml`**: froze every hook to its current tag's SHA (`prek auto-update --freeze --cooldown-days 7`); no hook had a release outside the cooldown window, so no versions moved. Also set `autoupdate_schedule: monthly` on the existing `ci:` block.
- **Closed a self-hosted-runner / fork-PR gap**: the `rucio` job in `uchicago.yml` already skipped itself for `pull_request` events from forks, but every other job on `arc-runner-set-uchicago` (including `test-actions` in `ci.yml`) had no such guard — any fork could open a PR and have its branch's shell scripts execute directly on the lab's self-hosted infrastructure. Applied the same `github.event.pull_request.head.repo.fork == false` guard everywhere that job pattern is used.

## Major version changes

None. `actions-up` moved every action reference to a SHA of the *same* tag it was already on (e.g. `actions/checkout@v7` → `v7.0.1` pinned by SHA); no major bumps were available/applicable. `prek auto-update` likewise found no hook releases outside the 7-day cooldown, so no pre-commit hook moved versions either.

One version note (not major, but worth flagging): `prefix-dev/setup-pixi` in `.github/actions/parse/action.yml` was on `v0.9.3` while `ci.yml`/`docs.yml` already used `v0.10.1`; `actions-up` brought it in line with the other two call sites at `v0.10.1` (SHA-pinned).

## Held back

- **`pixi.toml`: `exclude-newer` cooldown** — the skill's default step 6 asks for a 7-day `exclude-newer` cooldown on pixi-managed dependencies. `exclude-newer` was only added to pixi in **v0.67.0**, but this repo pins `pixi-version: v0.49.0` in three places (`ci.yml`, `docs.yml`, `.github/actions/parse/action.yml`). Adding the setting now would very likely break every `pixi run`/`pixi install` invocation in CI against an old pixi that doesn't recognize the field. Skipped; bumping pixi itself to ≥0.67.0 is a separate, non-security change that deserves its own PR and testing.

## zizmor ignores

- **`dangerous-triggers` on `semantic-pr-check.yml`** (`pull_request_target`): this workflow never checks out the PR's code — there's no `actions/checkout` step at all — and only reads the PR title via the GitHub API through `amannn/action-semantic-pull-request`. `pull_request_target` is used deliberately so PRs from forks still get a `statuses: write`-capable token to report the check; a plain `pull_request` trigger is forced read-only for fork PRs and would silently fail to post the status, defeating the point of validating first-time contributors' PR titles. Documented in `.github/zizmor.yml`.

## Verification

- `uvx zizmor --persona=pedantic --min-severity=low .github` → clean (0 low/medium/high findings; the informational job-naming findings are filtered by design and are not security-relevant).
- `uvx prek run --all-files` → all hooks pass, including the newly added `zizmor` hook.
- Every SHA pin verified against `git ls-remote` for its upstream tag ref before committing.
